### PR TITLE
Feature search

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ mostly a different way to access that data.
 
 Running
 
-    geojson-xyz airports --
+    geojson-xyz airports -
 
 Means "fuzzy-match airports and output results to stdout". You can substitute
 anything else for 'airports'. Outputting to stdout means you can pipe that

--- a/geojson-xyz
+++ b/geojson-xyz
@@ -44,7 +44,16 @@ if (argv._[0]) {
 
           if (options.filter && result.featureMatch && data.type === 'FeatureCollection') {
             data.features = data.features.filter(function (feat) {
-              return feat.properties[result.featureMatch.property] === result.featureMatch.value;
+              // manually iterate properties so we can be insensitive to letter
+              // case of keys
+              for (var key in feat.properties) {
+                if (key.toLowerCase() === result.featureMatch.property.toLowerCase()
+                    && feat.properties[key] === result.featureMatch.value) {
+                  return true;
+                }
+              }
+
+              return false;
             });
           }
 

--- a/geojson-xyz
+++ b/geojson-xyz
@@ -5,6 +5,7 @@ var inquirer = require('inquirer'),
   chalk = require('chalk'),
   toClipboard = require('to-clipboard'),
   geojsonStream = require('geojson-stream'),
+  queue = require('queue-async'),
   choices = require('./lib/choices'),
   xyz = require('./'),
   argv = require('yargs')
@@ -26,7 +27,7 @@ var options = {
 
 if (argv._[0]) {
   var stream;
-  if (argv._[1] === '-') {
+  if (argv._[1] === '-' || !process.stdout.isTTY) {
     stream = geojsonStream.stringify();
     stream.pipe(process.stdout);
   }
@@ -35,25 +36,35 @@ if (argv._[0]) {
     if (err) throw new Error(err);
     if (argv.metadataOnly) { return console.log(JSON.stringify(results, null, 2)); }
 
+    var q = queue();
     results.forEach(function (result) {
-      xyz.getURL(result.file.url, function (err, data) {
-        if (err) throw new Error(err);
+      q.defer(function (done) {
+        xyz.getURL(result.file.url, function (err, data) {
+          if (err) return done(err);
 
-        if (options.filter && result.featureMatch && data.type === 'FeatureCollection') {
-          data.features = data.features.filter(function (feat) {
-            return feat.properties[result.featureMatch.property] === result.featureMatch.value;
-          });
-        }
+          if (options.filter && result.featureMatch && data.type === 'FeatureCollection') {
+            data.features = data.features.filter(function (feat) {
+              return feat.properties[result.featureMatch.property] === result.featureMatch.value;
+            });
+          }
 
-        if (stream) {
-          var features = data.type === 'FeatureCollection' ? data.features : [data];
-          features.forEach(function (feat) { stream.write(feat); });
-        } else {
-          console.log(chalk.green('✓ ') + chalk.bold('saved as ' + result.file.name));
-          console.log(license);
-          fs.writeFileSync(result.file.name, JSON.stringify(result.data));
-        }
+          if (stream) {
+            var features = data.type === 'FeatureCollection' ? data.features : [data];
+            features.forEach(function (feat) { stream.write(feat); });
+          } else {
+            console.log(chalk.green('✓ ') + chalk.bold('saved as ' + result.file.name));
+            console.log(license);
+            fs.writeFileSync(result.file.name, JSON.stringify(result.data));
+          }
+
+          done();
+        });
       });
+    });
+
+    q.awaitAll(function (err) {
+      if (err) throw new Error(err);
+      if (stream) { stream.end(); }
     });
   });
   return;

--- a/geojson-xyz
+++ b/geojson-xyz
@@ -23,6 +23,11 @@ if (argv._[0]) {
   xyz.getGeoJSON(argv._[0], function (err, result) {
     if (err) throw new Error(err);
 
+    if (result.match.value && result.data.type === 'FeatureCollection') {
+      result.data.features = result.data.features.filter(function (feat) {
+        return feat.properties[result.match.property] === result.match.value;
+      });
+    }
 
     if (argv._[1] === '-') {
       console.log(JSON.stringify(result.data));

--- a/geojson-xyz
+++ b/geojson-xyz
@@ -54,7 +54,7 @@ if (argv._[0]) {
           } else {
             console.log(chalk.green('✓ ') + chalk.bold('saved as ' + result.file.name));
             console.log(license);
-            fs.writeFileSync(result.file.name, JSON.stringify(result.data));
+            fs.writeFileSync(result.file.name, JSON.stringify(data));
           }
 
           done();

--- a/geojson-xyz
+++ b/geojson-xyz
@@ -13,7 +13,6 @@ var inquirer = require('inquirer'),
     .help('help')
     .argv;
 
-var naturalEarthSlug = 'naturalearth-3.3.0';
 var license = 'SOURCE: http://www.naturalearthdata.com/ Public Domain (no restrictions)';
 
 var options = {
@@ -25,8 +24,8 @@ if (argv._[0]) {
     if (err) throw new Error(err);
 
 
-    if (argv._[1] === '--') {
-      console.log(JSON.stringify(result.data))
+    if (argv._[1] === '-') {
+      console.log(JSON.stringify(result.data));
     } else {
       console.log(chalk.green('✓ ') + chalk.bold('saved as ' + result.file.name));
       console.log(license);

--- a/geojson-xyz
+++ b/geojson-xyz
@@ -4,38 +4,57 @@ var inquirer = require('inquirer'),
   fs = require('fs'),
   chalk = require('chalk'),
   toClipboard = require('to-clipboard'),
+  geojsonStream = require('geojson-stream'),
   choices = require('./lib/choices'),
   xyz = require('./'),
   argv = require('yargs')
     .usage('Get GeoJSON\n$0')
     .boolean('all')
-    .describe('all', 'show files that are bigger than 2MB')
+    .describe('all', 'Get data from all files matching your search.')
+    .default('all', false)
+    .describe('filter', 'When the search matches a feature name within a file, filter that file\'s data down to the matching feature or features.')
+    .default('filter', true)
     .help('help')
     .argv;
 
 var license = 'SOURCE: http://www.naturalearthdata.com/ Public Domain (no restrictions)';
 
 var options = {
-  all: argv.all
+  all: argv.all,
+  filter: argv.filter
 };
 
 if (argv._[0]) {
-  xyz.getGeoJSON(argv._[0], function (err, result) {
+  var stream;
+  if (argv._[1] === '-') {
+    stream = geojsonStream.stringify();
+    stream.pipe(process.stdout);
+  }
+
+  xyz.getGeoJSON(argv._[0], argv, function (err, results) {
     if (err) throw new Error(err);
+    if (argv.metadataOnly) { return console.log(JSON.stringify(results, null, 2)); }
 
-    if (result.match.value && result.data.type === 'FeatureCollection') {
-      result.data.features = result.data.features.filter(function (feat) {
-        return feat.properties[result.match.property] === result.match.value;
+    results.forEach(function (result) {
+      xyz.getURL(result.file.url, function (err, data) {
+        if (err) throw new Error(err);
+
+        if (options.filter && result.featureMatch && data.type === 'FeatureCollection') {
+          data.features = data.features.filter(function (feat) {
+            return feat.properties[result.featureMatch.property] === result.featureMatch.value;
+          });
+        }
+
+        if (stream) {
+          var features = data.type === 'FeatureCollection' ? data.features : [data];
+          features.forEach(function (feat) { stream.write(feat); });
+        } else {
+          console.log(chalk.green('✓ ') + chalk.bold('saved as ' + result.file.name));
+          console.log(license);
+          fs.writeFileSync(result.file.name, JSON.stringify(result.data));
+        }
       });
-    }
-
-    if (argv._[1] === '-') {
-      console.log(JSON.stringify(result.data));
-    } else {
-      console.log(chalk.green('✓ ') + chalk.bold('saved as ' + result.file.name));
-      console.log(license);
-      fs.writeFileSync(result.file.name, JSON.stringify(result.data));
-    }
+    });
   });
   return;
 }

--- a/geojson-xyz
+++ b/geojson-xyz
@@ -44,16 +44,17 @@ if (argv._[0]) {
 
           if (options.filter && result.featureMatch && data.type === 'FeatureCollection') {
             data.features = data.features.filter(function (feat) {
-              // manually iterate properties so we can be insensitive to letter
-              // case of keys
-              for (var key in feat.properties) {
-                if (key.toLowerCase() === result.featureMatch.property.toLowerCase()
-                    && feat.properties[key] === result.featureMatch.value) {
-                  return true;
+              return result.featureMatch.some(function (featureMatch) {
+                // manually iterate properties so we can be insensitive to letter
+                // case of keys
+                for (var key in feat.properties) {
+                  if (key.toLowerCase() === featureMatch.property.toLowerCase()
+                      && feat.properties[key] === featureMatch.value) {
+                    return true;
+                  }
                 }
-              }
-
-              return false;
+                return false;
+              });
             });
           }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,36 @@
 var https = require('https'),
   fuzzy = require('./lib/fuzzy');
 
+/**
+ * @name geojsonXyz
+ * @param {string} fileSearch query: either a complete filename or a
+ * search term
+ * @param {object} options
+ * @param {Function} callback called with (err, [{ file, score, featureMatch }])
+ * @returns {undefined} calls callback
+ */
+function getGeoJSON(search, options, callback) {
+  fuzzy.findMatches(search, function (err, matches) {
+    if (!matches.length) return callback('no file matched your query', null);
+    var topMatch = matches[0];
+    matches = matches.filter(function (match, i) {
+      if (!options.all) { return i === 0; }
+      return match.score === topMatch.score;
+    })
+    .map(function (match) {
+      return {
+        file: match.original,
+        featureMatch: match.value ? {
+          property: match.property,
+          value: match.value
+        } : false,
+        score: match.score
+      };
+    });
+    return callback(null, matches);
+  });
+}
+
 function getURL(url, callback) {
   https.get(url, function(res) {
     var body = '';
@@ -14,22 +44,5 @@ function getURL(url, callback) {
   });
 }
 
-/**
- * @name geojsonXyz
- * @param {string} fileSearch query: either a complete filename or a
- * search term
- * @param {Function} callback called with (err, { file, geojson })
- * @returns {undefined} calls callback
- */
-function getGeoJSON(fileSearch, callback) {
-  fuzzy(fileSearch, function (err, match) {
-    if (!match) return callback('no file matched your query', null);
-    getURL(match.original.url, function (err, res) {
-      if (err) throw err;
-      callback(null, { data: res, file: match.original, match: match });
-    });
-  });
-}
-
-module.exports.getGeoJSON = getGeoJSON;
 module.exports.getURL = getURL;
+module.exports.getGeoJSON = getGeoJSON;

--- a/index.js
+++ b/index.js
@@ -22,13 +22,14 @@ function getURL(url, callback) {
  * @returns {undefined} calls callback
  */
 function getGeoJSON(fileSearch, callback) {
-  var file = fuzzy(fileSearch);
-  if (!file) return callback('no file matched your query', null);
-  getURL(file.original.url, function (err, res) {
+  fuzzy(fileSearch, function (err, match) {
+    if (!match) return callback('no file matched your query', null);
+    getURL(match.original.url, function (err, res) {
       if (err) throw err;
-      callback(null, { data: res, file: file.original });
+      callback(null, { data: res, file: match.original, match: match });
+    });
   });
-};
+}
 
 module.exports.getGeoJSON = getGeoJSON;
 module.exports.getURL = getURL;

--- a/lib/choices.js
+++ b/lib/choices.js
@@ -1,12 +1,11 @@
 var naturalEarth = require('geojson-xyz-data')['naturalearth-3.3.0'].files;
-var constants = require('./constants');
 
 var categories = Object.keys(naturalEarth.reduce(function (cats, meow) {
-    cats[meow.category] = true
-    return cats;
+  cats[meow.category] = true;
+  return cats;
 }, {}));
 
-module.exports = function(options) {
+module.exports = function() {
   return [
     {
       type: 'list',
@@ -20,12 +19,12 @@ module.exports = function(options) {
         name: 'file',
         message: 'What file?',
         choices: naturalEarth.filter(function (file) {
-            return file.category === category;
+          return file.category === category;
         }).map(function(file) {
-            return {
-                name: file.name,
-                value: file
-            };
+          return {
+            name: file.name,
+            value: file
+          };
         }),
         when: function(answers) {
           return answers.category === category;

--- a/lib/fuzzy.js
+++ b/lib/fuzzy.js
@@ -26,7 +26,7 @@ function findMatches (search, callback) {
     fs.createReadStream(data.index)
     .pipe(csv(['value', 'property', 'files']))
     .on('data', function (row) {
-      var match = fuzzy.match(search, row.value, {});
+      var match = fuzzy.match(search, row.property + ':' + row.value, {});
       if (match) {
         row.files.split(';').forEach(function (file) {
           matches.push({

--- a/lib/fuzzy.js
+++ b/lib/fuzzy.js
@@ -28,7 +28,7 @@ function findMatches (search, callback) {
     .on('data', function (row) {
       row.files.split(';').forEach(function (file) {
         file = filesByName[file];
-        var match = fuzzy.match(search, file.name + file.category + ':' + row.property + ':' + row.value, {});
+        var match = fuzzy.match(search, [row.value, row.property, file.name, file.category].join(':'), {});
         if (match) {
           matches.push({
             original: file,

--- a/lib/fuzzy.js
+++ b/lib/fuzzy.js
@@ -1,10 +1,56 @@
-var fuzzy = require('fuzzy'),
-  files = require('geojson-xyz-data')['naturalearth-3.3.0'].files;
+var fs = require('fs'),
+  fuzzy = require('fuzzy'),
+  csv = require('csv-parser'),
+  data = require('geojson-xyz-data')['naturalearth-3.3.0'];
 
-module.exports = function(search) {
-  return fuzzy.filter(search, files, {
-      extract: function(item) {
-          return item.name + item.category;
+var filesByName = {};
+data.files.forEach(function (file, i) {
+  file.order = i;
+  filesByName[file.name] = file;
+});
+
+function findMatches (search, callback) {
+  var matches = [];
+  data.files.forEach(function (file) {
+    var match = fuzzy.match(search, file.name + file.category, {});
+    if (match) {
+      matches.push({
+        original: file,
+        score: match.score
+      });
+    }
+  });
+
+  fs.stat(data.index, function (err) {
+    if (err) { return callback(null, matches); }
+    fs.createReadStream(data.index)
+    .pipe(csv(['value', 'property', 'files']))
+    .on('data', function (row) {
+      var match = fuzzy.match(search, row.value, {});
+      if (match) {
+        row.files.split(';').forEach(function (file) {
+          matches.push({
+            original: filesByName[file],
+            score: match.score,
+            property: row.property,
+            value: row.value
+          });
+        });
       }
-  })[0];
+    })
+    .on('end', function () {
+      matches.sort(function (a, b) {
+        var delta = b.score - a.score;
+        if (delta) { return delta; }
+        return a.original.order - b.original.order;
+      });
+      return callback(null, matches);
+    });
+  });
+}
+
+module.exports = function (search, callback) {
+  findMatches(search, function (err, matches) { callback(err, matches && matches[0]); });
 };
+
+module.exports.findMatches = findMatches;

--- a/lib/fuzzy.js
+++ b/lib/fuzzy.js
@@ -24,19 +24,20 @@ function findMatches (search, callback) {
   fs.stat(data.index, function (err) {
     if (err) { return callback(null, matches); }
     fs.createReadStream(data.index)
-    .pipe(csv(['value', 'property', 'files']))
+    .pipe(csv())
     .on('data', function (row) {
-      var match = fuzzy.match(search, row.property + ':' + row.value, {});
-      if (match) {
-        row.files.split(';').forEach(function (file) {
+      row.files.split(';').forEach(function (file) {
+        file = filesByName[file];
+        var match = fuzzy.match(search, file.name + file.category + ':' + row.property + ':' + row.value, {});
+        if (match) {
           matches.push({
-            original: filesByName[file],
+            original: file,
             score: match.score,
             property: row.property,
             value: row.value
           });
-        });
-      }
+        }
+      });
     })
     .on('end', function () {
       matches.sort(function (a, b) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "geojson-xyz": "./geojson-xyz"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "tap test/*.js"
   },
   "repository": {
     "type": "git",
@@ -27,11 +27,15 @@
   "homepage": "https://github.com/tmcw/geojson-xyz#readme",
   "dependencies": {
     "chalk": "^1.1.1",
+    "csv-parser": "^1.9.2",
     "fuzzy": "^0.1.1",
-    "geojson-xyz-data": "^3.0.0",
+    "geojson-xyz-data": "anandthakker/geojson-xyz-data#aea16ebbd79eb5ed893e0e686a0a8aea0cb37afe",
     "inquirer": "^0.10.1",
     "minimist": "^1.2.0",
     "to-clipboard": "^0.2.0",
     "yargs": "^3.29.0"
+  },
+  "devDependencies": {
+    "tap": "^5.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "csv-parser": "^1.9.2",
     "fuzzy": "^0.1.1",
     "geojson-stream": "0.0.1",
-    "geojson-xyz-data": "anandthakker/geojson-xyz-data#1521ff8a18189095e651208ea4e09d4d2d9a74d4",
+    "geojson-xyz-data": "^3.1.0",
     "inquirer": "^0.10.1",
     "minimist": "^1.2.0",
     "queue-async": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "csv-parser": "^1.9.2",
     "fuzzy": "^0.1.1",
     "geojson-stream": "0.0.1",
-    "geojson-xyz-data": "anandthakker/geojson-xyz-data#aea16ebbd79eb5ed893e0e686a0a8aea0cb37afe",
+    "geojson-xyz-data": "anandthakker/geojson-xyz-data#1521ff8a18189095e651208ea4e09d4d2d9a74d4",
     "inquirer": "^0.10.1",
     "minimist": "^1.2.0",
     "queue-async": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "chalk": "^1.1.1",
     "csv-parser": "^1.9.2",
     "fuzzy": "^0.1.1",
+    "geojson-stream": "0.0.1",
     "geojson-xyz-data": "anandthakker/geojson-xyz-data#aea16ebbd79eb5ed893e0e686a0a8aea0cb37afe",
     "inquirer": "^0.10.1",
     "minimist": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "geojson-xyz-data": "anandthakker/geojson-xyz-data#aea16ebbd79eb5ed893e0e686a0a8aea0cb37afe",
     "inquirer": "^0.10.1",
     "minimist": "^1.2.0",
+    "queue-async": "^1.2.0",
     "to-clipboard": "^0.2.0",
     "yargs": "^3.29.0"
   },

--- a/test/fuzzy.js
+++ b/test/fuzzy.js
@@ -1,0 +1,16 @@
+var test = require('tap').test;
+var fuzzy = require('../lib/fuzzy');
+
+test('search finds filenames', {skip: true}, function (t) {
+  fuzzy('ocean', function (err, match) {
+    t.equal(match.original.name, 'ne_50m_ocean.geojson', 'direct hit');
+    t.end();
+  });
+});
+
+test('search finds file by feature name', function (t) {
+  fuzzy('maryland', function (err, match) {
+    t.equal(match.value.toLowerCase(), 'maryland', 'find feature');
+    t.end();
+  });
+});

--- a/test/fuzzy.js
+++ b/test/fuzzy.js
@@ -1,7 +1,7 @@
 var test = require('tap').test;
 var fuzzy = require('../lib/fuzzy');
 
-test('search finds filenames', {skip: true}, function (t) {
+test('search finds filenames', function (t) {
   fuzzy('ocean', function (err, match) {
     t.equal(match.original.name, 'ne_50m_ocean.geojson', 'direct hit');
     t.end();
@@ -14,3 +14,4 @@ test('search finds file by feature name', function (t) {
     t.end();
   });
 });
+


### PR DESCRIPTION
Adds feature search functionality to the fuzzy match ( #9 ):
- If `node_modules/geojson-xyz-data/naturalearth-3.3.0/name-index.csv` is present, include that in the fuzzy search.
- When search result comes from a feature name match, default to outputting just that feature (or features), unless `--no-filter` is set.

This depends on the PR upstream in `geojson-xyz-data`: https://github.com/geojson-xyz/geojson-xyz-data/pull/6 -- if/when that gets merged, the `package.json` dependency for that needs to be changed back to normal.
